### PR TITLE
fixes double render in react strict mode

### DIFF
--- a/src/qognicafinance-react-lightweight-charts.js
+++ b/src/qognicafinance-react-lightweight-charts.js
@@ -63,6 +63,7 @@ class ChartWrapper extends React.Component {
     }
 
     componentDidMount() {
+        if (this.chart) return;
         this.chart = createChart(this.chartDiv.current);
         this.handleUpdateChart();
         this.resizeHandler();


### PR DESCRIPTION
Double rendering causes two charts to be generated in react strict mode. Checking if the chart is already created prevents that issue.